### PR TITLE
Fix lint config

### DIFF
--- a/packages/scene-viewer-panels/.stylelintrc.js
+++ b/packages/scene-viewer-panels/.stylelintrc.js
@@ -22,6 +22,7 @@ module.exports = {
     "rule-empty-line-before": null,
     "no-empty-first-line": null,
     "no-eol-whitespace": null,
+    "value-keyword-case": null,
   },
   reportNeedlessDisables: true,
   reportInvalidScopeDisables: true,

--- a/packages/scene-viewer-panels/tsconfig.json
+++ b/packages/scene-viewer-panels/tsconfig.json
@@ -28,7 +28,8 @@
     "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
     "target": "es6",
-    "downlevelIteration": true
+    "downlevelIteration": true,
+    "strictBindCallApply": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist", "example"]


### PR DESCRIPTION
## What?
- Fix lint config

## Why?
- スタイリングの値に大文字を用いたいから
- storybook の Story 型に補完を利かせたいから