### PR TITLE
Remap ROS-topics and remove template-publisher from ros1.launch

### DIFF
--- a/packages/ros1_nodes/launch/ros1.launch
+++ b/packages/ros1_nodes/launch/ros1.launch
@@ -20,17 +20,12 @@
       <arg name="websocket_external_port" value="$(arg websocket_external_port)" />
     </include>
 
-    <!-- Template node -->
-    <node pkg="scene_viewer" type="template_publisher.py" name="template_publisher"
-          required="true" output="screen" clear_params="true">
-          <param name="path_to_config_file" value="$(find scene_viewer)/conf/default.yaml" />
-    </node>
-
     <!-- File reader -->
     <node pkg="scene_viewer" type="file_reader.py" name="caption_reader"
           required="true" output="screen" clear_params="true">
           <param name="path_to_config_file" value="$(find scene_viewer)/conf/default.yaml" />
           <param name="path_to_file" value="$(arg path_to_caption_file)" />
+          <remap from="~content" to="/scene_viewer/scene_captions" />
     </node>
 
     <!-- Trajectory Publisher -->
@@ -39,6 +34,7 @@
           <param name="path_to_config_file" value="$(find scene_viewer)/conf/default.yaml" />
           <param name="path_to_rosbag" value="$(arg path_to_rosbag)" />
           <param name="gnss_topic" value="$(arg gnss_topic)" />
+          <remap from="~info" to="/scene_viewer/vehicle_trajectory" />
     </node>
 
 </launch>


### PR DESCRIPTION
## What?
- Remap the following topics
  - `/caption_reader/content` -> `/scene_viewer/scene_captions`
  - `/trajectory_publisher/info` -> `/scene_viewer/vehicle_trajectory`

## Why?
To standardize