### PR TITLE
Add jq to ros1-nodes

### DIFF
--- a/packages/ros1_nodes/Dockerfile
+++ b/packages/ros1_nodes/Dockerfile
@@ -12,6 +12,7 @@ RUN apt update \
       wget \
       vim \
       git \
+      jq \
       python3-pip \
     && apt upgrade -y \
     && rosdep update \


### PR DESCRIPTION
## What?
Add `jq` to the dockerfile of ros1-nodes

## Why?
To use jq in ros-provider-with-scene-caption job

## See also
[dataware-tools/api-job-store#26](https://github.com/dataware-tools/api-job-store/pull/26)