### PR TITLE
Export roslibhooks from scene-viewer-panels

### DIFF
--- a/packages/scene-viewer-panels/package.json
+++ b/packages/scene-viewer-panels/package.json
@@ -81,7 +81,8 @@
     "node": "12.22.7"
   },
   "peerDependencies": {
-    "react": "16.10.2"
+    "react": "16.10.2",
+    "roslib": "^1.1.0"
   },
   "dependencies": {
     "@emotion/css": "^11.5.0",

--- a/packages/scene-viewer-panels/src/index.ts
+++ b/packages/scene-viewer-panels/src/index.ts
@@ -2,3 +2,4 @@ export * from "./Sample";
 export * from "./CurrentCaption";
 export * from "./SceneSelector";
 export * from "./MapPanel";
+export * from "./hooks/roslibHooks";


### PR DESCRIPTION
## What?
- Export roslib hooks from scene-viewer-panels

## Why?
- To use roslib hooks in webviz