### PR TITLE
Add tracking current position on map

### DIFF
--- a/packages/scene-viewer-panels/src/MapPanel/index.tsx
+++ b/packages/scene-viewer-panels/src/MapPanel/index.tsx
@@ -113,30 +113,33 @@ export const MapPanel = ({
   // Add button element to enable tracking position on map
   useEffect(() => {
     if (!map) return;
-    const MapHelp = Leaflet.Control.extend({
-      onAdd: () => {
-        const helpDiv = Leaflet.DomUtil.create("div", "leaflet-bar");
-        helpDiv.innerHTML = `
-          ${ReactDOMServer.renderToString(
-            <a
-              role="button"
-              className={css`
-                cursor: pointer;
-                font-size: 22px;
-              `}
-            >
-              <GpsFixedIcon />
-            </a>
-          )}
-        `;
-        helpDiv.addEventListener("click", () => {
-          setTrackCurrentPosition(true);
-        });
-        return helpDiv;
-      },
+
+    const trackCurrentPositionButton = Leaflet.DomUtil.create(
+      "div",
+      "leaflet-bar"
+    );
+    trackCurrentPositionButton.innerHTML = `
+      ${ReactDOMServer.renderToString(
+        <a
+          role="button"
+          className={css`
+            cursor: pointer;
+            font-size: 22px;
+          `}
+        >
+          <GpsFixedIcon />
+        </a>
+      )}
+    `;
+    trackCurrentPositionButton.addEventListener("click", () => {
+      setTrackCurrentPosition(true);
     });
-    const trackCurrentPositionButton = new MapHelp({ position: "bottomleft" });
-    trackCurrentPositionButton.addTo(map);
+
+    // Extend leaflet control class (see https://leafletjs.com/examples/extending/extending-1-classes.html)
+    const trackCurrentPositionButtonControl = new (Leaflet.Control.extend({
+      onAdd: () => trackCurrentPositionButton,
+    }))({ position: "bottomleft" });
+    trackCurrentPositionButtonControl.addTo(map);
   }, [map, setTrackCurrentPosition]);
 
   return (


### PR DESCRIPTION
## What?

現在位置に追従して地図を動かす機能を追加
インタラクション：
- 左下のボタンを押すと追従するようになる
- ドラッグして動かすと追従されなくなる

## Why?

現在位置に追従してほしい

## See also [Optional]

- https://react-leaflet.js.org/docs/example-external-state/
- https://codesandbox.io/s/react-leaflet-description-button-o66nb?file=/src/Description.js

## Screenshot or video [Optional]

https://user-images.githubusercontent.com/13210107/146503128-599ba29a-51f1-4693-bd78-ad409d0c3d2f.mp4


