### PR TITLE
Use github hosted runner

### DIFF
--- a/.github/workflows/build-and-merge.yaml
+++ b/.github/workflows/build-and-merge.yaml
@@ -14,4 +14,4 @@ jobs:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           repository: dataware-tools/web-deployment
           event-type: build-and-deploy
-          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "repo_name": "${{ github.event.repository.name }}", "repo_full_name": "${{ github.event.repository.full_name }}"}'
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "repo_name": "${{ github.event.repository.name }}", "repo_full_name": "${{ github.event.repository.full_name }}", "self_hosted": "false"}'


### PR DESCRIPTION
## What?
Use github hosted runner

## Why?
パブリックリポジトリから self-hosted runner を使うのはセキュリティ的にまずいので
